### PR TITLE
System settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
 	QuickLootIE
-	VERSION 3.0.0
+	VERSION 3.1.0
 	LANGUAGES CXX
 )
 

--- a/res/QuickLootIE.json
+++ b/res/QuickLootIE.json
@@ -1,0 +1,9 @@
+{
+	"logLevel": "trace",
+	"logFlush": "trace",
+	"menuWhitelist": [
+		"AchievementWidget",
+		"BestiaryWidget",
+		"Durability Menu"
+	]
+}

--- a/res/QuickLootIE.json
+++ b/res/QuickLootIE.json
@@ -1,6 +1,7 @@
 {
 	"logLevel": "trace",
 	"logFlush": "trace",
+	"skipOldSwfCheck": false,
 	"menuWhitelist": [
 		"AchievementWidget",
 		"BestiaryWidget",

--- a/res/QuickLootIE.json
+++ b/res/QuickLootIE.json
@@ -6,5 +6,8 @@
 		"AchievementWidget",
 		"BestiaryWidget",
 		"Durability Menu"
+	],
+	"containerBlacklist": [
+		"Skyrim.esm|000000"
 	]
 }

--- a/res/pex/Source/Scripts/QuickLootIEMCM.psc
+++ b/res/pex/Source/Scripts/QuickLootIEMCM.psc
@@ -1175,6 +1175,40 @@ state state_ControlsTransferModifier
 	endevent
 endstate
 
+state state_ControlsDisableModifier
+	event OnMenuOpenST()
+		SetMenuDialogStartIndex(0)
+		SetMenuDialogDefaultIndex(0)
+		SetMenuDialogOptions(KeyModifierOptions)
+	endevent
+
+	event OnMenuAcceptST(int index)
+		QLIE_KeybindingDisableModifier = index
+		SetMenuOptionValueST(KeyModifierOptions[QLIE_KeybindingDisableModifier])
+	endevent
+
+	event OnHighlightST()
+		SetInfoText("$qlie_ControlsModifier_info")
+	endevent
+endstate
+
+state state_ControlsEnableModifier
+	event OnMenuOpenST()
+		SetMenuDialogStartIndex(0)
+		SetMenuDialogDefaultIndex(0)
+		SetMenuDialogOptions(KeyModifierOptions)
+	endevent
+
+	event OnMenuAcceptST(int index)
+		QLIE_KeybindingEnableModifier = index
+		SetMenuOptionValueST(KeyModifierOptions[QLIE_KeybindingEnableModifier])
+	endevent
+
+	event OnHighlightST()
+		SetInfoText("$qlie_ControlsModifier_info")
+	endevent
+endstate
+
 state state_ControlReset
 	event OnSelectST()
 		ResetControls()

--- a/src/Config/Papyrus.cpp
+++ b/src/Config/Papyrus.cpp
@@ -1,7 +1,7 @@
 #include "Papyrus.h"
 
 #include "LootMenu.h"
-#include "Settings.h"
+#include "UserSettings.h"
 #include "Util/ScriptObject.h"
 
 namespace QuickLoot::Config
@@ -46,7 +46,7 @@ namespace QuickLoot::Config
 
 		logger::info("MCM pointer set successfully");
 
-		Settings::Update();
+		UserSettings::Update();
 	};
 
 	void Papyrus::UpdateVariables(RE::StaticFunctionTag*)

--- a/src/Config/SystemSettings.cpp
+++ b/src/Config/SystemSettings.cpp
@@ -21,6 +21,8 @@ namespace QuickLoot::Config
 			return;
 		}
 
+		_skipOldSwfCheck = config.value("skipOldSwfCheck", false);
+
 		UpdateLogLevel(config);
 		UpdateMenuWhitelist(config);
 	}

--- a/src/Config/SystemSettings.cpp
+++ b/src/Config/SystemSettings.cpp
@@ -1,5 +1,7 @@
 #include "SystemSettings.h"
 
+#include "Util/FormUtil.h"
+
 namespace QuickLoot::Config
 {
 	void SystemSettings::Update()
@@ -25,6 +27,7 @@ namespace QuickLoot::Config
 
 		UpdateLogLevel(config);
 		UpdateMenuWhitelist(config);
+		UpdateContainerBlacklist(config);
 	}
 
 	void SystemSettings::UpdateLogLevel(const json& config)
@@ -59,6 +62,32 @@ namespace QuickLoot::Config
 			const auto menu = menuJson.get<std::string>();
 			_menuWhitelist.push_back(menu);
 			logger::trace("Whitelisted menu: {}", menu);
+		}
+	}
+
+	void SystemSettings::UpdateContainerBlacklist(const json& config)
+	{
+		_containerBlacklist.clear();
+
+		if (!config.contains("containerBlacklist")) {
+			return;
+		}
+
+		const auto blacklistJson = config.at("containerBlacklist");
+		if (!blacklistJson.is_array()) {
+			logger::warn("Container blacklist wasn't an array");
+			return;
+		}
+
+		for (auto& formJson : blacklistJson) {
+			if (!formJson.is_string()) {
+				logger::warn("Container blacklist contained non-string value ({})", formJson.type_name());
+				continue;
+			}
+
+			const auto identifier = formJson.get<std::string>();
+			_containerBlacklist.insert(Util::FormUtil::ParseFormID(identifier));
+			logger::trace("Blacklisted container: {}", identifier);
 		}
 	}
 }

--- a/src/Config/SystemSettings.cpp
+++ b/src/Config/SystemSettings.cpp
@@ -1,0 +1,62 @@
+#include "SystemSettings.h"
+
+namespace QuickLoot::Config
+{
+	void SystemSettings::Update()
+	{
+		json config{};
+
+		try {
+			std::ifstream ifs;
+			ifs.open(CONFIG_PATH, std::ios::in);
+
+			if (!ifs.is_open()) {
+				logger::info("No system settings file present");
+				return;
+			}
+
+			ifs >> config;
+		} catch (nlohmann::json::parse_error& error) {
+			logger::error("Failed to parse system settings file: {}", error.what());
+			return;
+		}
+
+		UpdateLogLevel(config);
+		UpdateMenuWhitelist(config);
+	}
+
+	void SystemSettings::UpdateLogLevel(const json& config)
+	{
+		const auto logLevel = config.value("logLevel", "info");
+		const auto flushLevel = config.value("logFlush", logLevel);
+
+		spdlog::default_logger()->set_level(spdlog::level::from_str(logLevel));
+		spdlog::default_logger()->flush_on(spdlog::level::from_str(flushLevel));
+	}
+
+	void SystemSettings::UpdateMenuWhitelist(const json& config)
+	{
+		_menuWhitelist.clear();
+
+		if (!config.contains("menuWhitelist")) {
+			return;
+		}
+
+		const auto whitelistJson = config.at("menuWhitelist");
+		if (!whitelistJson.is_array()) {
+			logger::warn("Menu whitelist wasn't an array");
+			return;
+		}
+
+		for (auto& menuJson : whitelistJson) {
+			if (!menuJson.is_string()) {
+				logger::warn("Menu whitelist contained non-string value ({})", menuJson.type_name());
+				continue;
+			}
+
+			const auto menu = menuJson.get<std::string>();
+			_menuWhitelist.push_back(menu);
+			logger::trace("Whitelisted menu: {}", menu);
+		}
+	}
+}

--- a/src/Config/SystemSettings.h
+++ b/src/Config/SystemSettings.h
@@ -15,14 +15,17 @@ namespace QuickLoot::Config
 		static void Update();
 		static void UpdateLogLevel(const json& config);
 		static void UpdateMenuWhitelist(const json& config);
+		static void UpdateContainerBlacklist(const json& config);
 
 		static bool SkipOldSwfCheck() { return _skipOldSwfCheck; };
 		static const std::vector<std::string>& GetMenuWhitelist() { return _menuWhitelist; }
+		static const std::set<RE::FormID>& GetContainerBlacklist() { return _containerBlacklist; }
 
 	private:
 		static constexpr auto CONFIG_PATH = "Data\\SKSE\\Plugins\\QuickLootIE.json";
 
 		static inline bool _skipOldSwfCheck = false;
 		static inline std::vector<std::string> _menuWhitelist{};
+		static inline std::set<RE::FormID> _containerBlacklist{};
 	};
 }

--- a/src/Config/SystemSettings.h
+++ b/src/Config/SystemSettings.h
@@ -15,12 +15,14 @@ namespace QuickLoot::Config
 		static void Update();
 		static void UpdateLogLevel(const json& config);
 		static void UpdateMenuWhitelist(const json& config);
-		
+
+		static bool SkipOldSwfCheck() { return _skipOldSwfCheck; };
 		static const std::vector<std::string>& GetMenuWhitelist() { return _menuWhitelist; }
 
 	private:
 		static constexpr auto CONFIG_PATH = "Data\\SKSE\\Plugins\\QuickLootIE.json";
 
+		static inline bool _skipOldSwfCheck = false;
 		static inline std::vector<std::string> _menuWhitelist{};
 	};
 }

--- a/src/Config/SystemSettings.h
+++ b/src/Config/SystemSettings.h
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace QuickLoot::Config
+{
+	class SystemSettings
+	{
+	public:
+		SystemSettings() = delete;
+		~SystemSettings() = delete;
+		SystemSettings(SystemSettings const&) = delete;
+		SystemSettings(SystemSettings const&&) = delete;
+		SystemSettings operator=(SystemSettings&) = delete;
+		SystemSettings operator=(SystemSettings&&) = delete;
+
+		static void Update();
+		static void UpdateLogLevel(const json& config);
+		static void UpdateMenuWhitelist(const json& config);
+		
+		static const std::vector<std::string>& GetMenuWhitelist() { return _menuWhitelist; }
+
+	private:
+		static constexpr auto CONFIG_PATH = "Data\\SKSE\\Plugins\\QuickLootIE.json";
+
+		static inline std::vector<std::string> _menuWhitelist{};
+	};
+}

--- a/src/Config/UserSettings.cpp
+++ b/src/Config/UserSettings.cpp
@@ -1,12 +1,13 @@
-#include "Settings.h"
+#include "UserSettings.h"
 
+#include "LootMenu.h"
 #include "Behaviors/LockpickActivation.h"
 #include "Config/Papyrus.h"
 #include "Input/InputManager.h"
 
 namespace QuickLoot::Config
 {
-	void Settings::Update()
+	void UserSettings::Update()
 	{
 		Papyrus::UpdateVariables();
 
@@ -19,35 +20,35 @@ namespace QuickLoot::Config
 		Input::InputManager::UpdateMappings();
 	}
 
-	bool Settings::ShowInCombat() { return QLIE_ShowInCombat; }
-	bool Settings::ShowWhenEmpty() { return QLIE_ShowWhenEmpty; }
-	bool Settings::ShowWhenUnlocked() { return QLIE_ShowWhenUnlocked; }
-	bool Settings::ShowInThirdPersonView() { return QLIE_ShowInThirdPerson; }
-	bool Settings::ShowWhenMounted() { return QLIE_ShowWhenMounted; }
-	bool Settings::EnableForAnimals() { return QLIE_EnableForAnimals; }
-	bool Settings::EnableForDragons() { return QLIE_EnableForDragons; }
-	bool Settings::DispelInvisibility() { return QLIE_BreakInvisibility; }
+	bool UserSettings::ShowInCombat() { return QLIE_ShowInCombat; }
+	bool UserSettings::ShowWhenEmpty() { return QLIE_ShowWhenEmpty; }
+	bool UserSettings::ShowWhenUnlocked() { return QLIE_ShowWhenUnlocked; }
+	bool UserSettings::ShowInThirdPersonView() { return QLIE_ShowInThirdPerson; }
+	bool UserSettings::ShowWhenMounted() { return QLIE_ShowWhenMounted; }
+	bool UserSettings::EnableForAnimals() { return QLIE_EnableForAnimals; }
+	bool UserSettings::EnableForDragons() { return QLIE_EnableForDragons; }
+	bool UserSettings::DispelInvisibility() { return QLIE_BreakInvisibility; }
 
-	int Settings::GetWindowX() { return QLIE_WindowOffsetX; }
-	int Settings::GetWindowY() { return QLIE_WindowOffsetY; }
-	float Settings::GetWindowScale() { return QLIE_WindowScale; }
-	AnchorPoint Settings::GetWindowAnchor() { return static_cast<AnchorPoint>(QLIE_WindowAnchor); }
-	int Settings::GetWindowMinLines() { return QLIE_WindowMinLines; }
-	int Settings::GetWindowMaxLines() { return QLIE_WindowMaxLines; }
-	float Settings::GetWindowOpacityNormal() { return QLIE_WindowOpacityNormal; }
-	float Settings::GetWindowOpacityEmpty() { return QLIE_WindowOpacityEmpty; }
+	int UserSettings::GetWindowX() { return QLIE_WindowOffsetX; }
+	int UserSettings::GetWindowY() { return QLIE_WindowOffsetY; }
+	float UserSettings::GetWindowScale() { return QLIE_WindowScale; }
+	AnchorPoint UserSettings::GetWindowAnchor() { return static_cast<AnchorPoint>(QLIE_WindowAnchor); }
+	int UserSettings::GetWindowMinLines() { return QLIE_WindowMinLines; }
+	int UserSettings::GetWindowMaxLines() { return QLIE_WindowMaxLines; }
+	float UserSettings::GetWindowOpacityNormal() { return QLIE_WindowOpacityNormal; }
+	float UserSettings::GetWindowOpacityEmpty() { return QLIE_WindowOpacityEmpty; }
 
-	bool Settings::ShowIconRead() { return QLIE_ShowIconRead; }
-	bool Settings::ShowIconStolen() { return QLIE_ShowIconStolen; }
-	bool Settings::ShowIconEnchanted() { return QLIE_ShowIconEnchanted; }
-	bool Settings::ShowIconEnchantedKnown() { return QLIE_ShowIconEnchantedKnown; }
-	bool Settings::ShowIconEnchantedSpecial() { return QLIE_ShowIconEnchantedSpecial; }
+	bool UserSettings::ShowIconRead() { return QLIE_ShowIconRead; }
+	bool UserSettings::ShowIconStolen() { return QLIE_ShowIconStolen; }
+	bool UserSettings::ShowIconEnchanted() { return QLIE_ShowIconEnchanted; }
+	bool UserSettings::ShowIconEnchantedKnown() { return QLIE_ShowIconEnchantedKnown; }
+	bool UserSettings::ShowIconEnchantedSpecial() { return QLIE_ShowIconEnchantedSpecial; }
 
-	std::vector<std::string> Settings::GetInfoColumns() { return QLIE_InfoColumns; }
+	std::vector<std::string> UserSettings::GetInfoColumns() { return QLIE_InfoColumns; }
 
-	const std::vector<std::string>& Settings::GetUserDefinedSortPriority() { return QLIE_SortRulesActive; }
+	const std::vector<std::string>& UserSettings::GetUserDefinedSortPriority() { return QLIE_SortRulesActive; }
 
-	std::vector<Input::Keybinding> Settings::GetKeybindings()
+	std::vector<Input::Keybinding> UserSettings::GetKeybindings()
 	{
 		std::vector keybindings{
 			BuildKeybinding(Input::ControlGroup::kButtonBar, Input::QuickLootAction::kTake, QLIE_KeybindingTake, QLIE_KeybindingTakeModifier),
@@ -69,13 +70,13 @@ namespace QuickLoot::Config
 		return keybindings;
 	}
 
-	bool Settings::ShowArtifactDisplayed() { return QLIE_ShowIconArtifactDisplayed; }
-	bool Settings::ShowArtifactFound() { return QLIE_ShowIconArtifactCarried; }
-	bool Settings::ShowArtifactNew() { return QLIE_ShowIconArtifactNew; }
-	bool Settings::ShowCompletionistNeeded() { return QLIE_ShowIconCompletionistNeeded; }
-	bool Settings::ShowCompletionistCollected() { return QLIE_ShowIconCompletionistCollected; }
+	bool UserSettings::ShowArtifactDisplayed() { return QLIE_ShowIconArtifactDisplayed; }
+	bool UserSettings::ShowArtifactFound() { return QLIE_ShowIconArtifactCarried; }
+	bool UserSettings::ShowArtifactNew() { return QLIE_ShowIconArtifactNew; }
+	bool UserSettings::ShowCompletionistNeeded() { return QLIE_ShowIconCompletionistNeeded; }
+	bool UserSettings::ShowCompletionistCollected() { return QLIE_ShowIconCompletionistCollected; }
 
-	Input::Keybinding Settings::BuildKeybinding(Input::ControlGroup group, Input::QuickLootAction action, int skseKey, int modifierType)
+	Input::Keybinding UserSettings::BuildKeybinding(Input::ControlGroup group, Input::QuickLootAction action, int skseKey, int modifierType)
 	{
 		Input::ModifierKeys modifiers = ModifierTypeToModifierKeys(modifierType);
 		Input::DeviceType deviceType;
@@ -86,7 +87,7 @@ namespace QuickLoot::Config
 		return Input::Keybinding{ group, deviceType, keyCode, modifiers, action, false, 0.0f, global };
 	}
 
-	Input::ModifierKeys Settings::ModifierTypeToModifierKeys(int modifierType)
+	Input::ModifierKeys UserSettings::ModifierTypeToModifierKeys(int modifierType)
 	{
 		switch (modifierType) {
 		case 1:
@@ -102,7 +103,7 @@ namespace QuickLoot::Config
 		}
 	}
 
-	void Settings::SkseKeyToDeviceKey(int skseKey, Input::DeviceType& deviceType, uint16_t& keyCode)
+	void UserSettings::SkseKeyToDeviceKey(int skseKey, Input::DeviceType& deviceType, uint16_t& keyCode)
 	{
 		if (skseKey >= 266) {
 			deviceType = Input::DeviceType::kGamepad;

--- a/src/Config/UserSettings.h
+++ b/src/Config/UserSettings.h
@@ -16,15 +16,15 @@ namespace QuickLoot::Config
 		kBottomRight,
 	};
 
-	class Settings
+	class UserSettings
 	{
 	public:
-		Settings() = delete;
-		~Settings() = delete;
-		Settings(Settings const&) = delete;
-		Settings(Settings const&&) = delete;
-		Settings operator=(Settings&) = delete;
-		Settings operator=(Settings&&) = delete;
+		UserSettings() = delete;
+		~UserSettings() = delete;
+		UserSettings(UserSettings const&) = delete;
+		UserSettings(UserSettings const&&) = delete;
+		UserSettings operator=(UserSettings&) = delete;
+		UserSettings operator=(UserSettings&&) = delete;
 
 		static void Update();
 

--- a/src/Items/ItemListEntry.cpp
+++ b/src/Items/ItemListEntry.cpp
@@ -1,10 +1,10 @@
 #include "ItemListEntry.h"
 
-#include "Config/Settings.h"
+#include "Config/UserSettings.h"
 #include "Integrations/Completionist.h"
 #include "Integrations/Artifacts.h"
 
-using Settings = QuickLoot::Config::Settings;
+using Settings = QuickLoot::Config::UserSettings;
 
 #undef GetModuleHandle
 

--- a/src/LootMenu.cpp
+++ b/src/LootMenu.cpp
@@ -5,7 +5,7 @@
 #include "CLIK/GFx/Controls/ButtonBar.h"
 #include "CLIK/GFx/Controls/ScrollingList.h"
 #include "CLIK/TextField.h"
-#include "Config/Settings.h"
+#include "Config/UserSettings.h"
 #include "Input/ButtonArt.h"
 #include "Input/InputManager.h"
 #include "Integrations/APIServer.h"

--- a/src/LootMenu.cpp
+++ b/src/LootMenu.cpp
@@ -55,6 +55,7 @@ namespace QuickLoot
 	LootMenu::LootMenu()
 	{
 		depthPriority = 3;
+		menuName = MENU_NAME;
 		menuFlags.set(Flag::kAllowSaving, Flag::kHasButtonBar);
 
 		RE::BSScaleformManager::GetSingleton()->LoadMovie(this, uiMovie, FILE_NAME.data());

--- a/src/LootMenu.h
+++ b/src/LootMenu.h
@@ -5,11 +5,11 @@
 #include "CLIK/GFx/Controls/ButtonBar.h"
 #include "CLIK/GFx/Controls/ScrollingList.h"
 #include "CLIK/TextField.h"
-#include "Config/Settings.h"
+#include "Config/UserSettings.h"
 #include "Input/Input.h"
 #include "Items/OldItem.h"
 
-using Settings = QuickLoot::Config::Settings;
+using Settings = QuickLoot::Config::UserSettings;
 
 namespace QuickLoot
 {

--- a/src/MenuVisibilityManager.cpp
+++ b/src/MenuVisibilityManager.cpp
@@ -99,6 +99,21 @@ namespace QuickLoot
 		return nullptr;
 	}
 
+	bool MenuVisibilityManager::IsContainerBlacklisted(const RE::TESObjectREFRPtr& container)
+	{
+		const auto& blacklist = Config::SystemSettings::GetContainerBlacklist();
+
+		if (blacklist.contains(container->formID)) {
+			return true;
+		}
+
+		if (const auto baseObj = container->GetBaseObject()) {
+			return blacklist.contains(baseObj->formID);
+		}
+
+		return false;
+	}
+
 	bool MenuVisibilityManager::CanOpen(const RE::TESObjectREFRPtr& container)
 	{
 		const auto player = RE::PlayerCharacter::GetSingleton();
@@ -145,6 +160,11 @@ namespace QuickLoot
 
 		if (RE::UI::GetSingleton()->GameIsPaused()) {
 			logger::debug("LootMenu disabled because the game is paused");
+			return false;
+		}
+
+		if (IsContainerBlacklisted(container)) {
+			logger::debug("LootMenu disabled because the container is blacklisted ({:08X})", container->formID);
 			return false;
 		}
 

--- a/src/MenuVisibilityManager.cpp
+++ b/src/MenuVisibilityManager.cpp
@@ -1,6 +1,6 @@
 #include "MenuVisibilityManager.h"
 
-#include "Config/Settings.h"
+#include "Config/UserSettings.h"
 #include "LootMenu.h"
 #include "LootMenuManager.h"
 #include "Observers/CameraStateObserver.h"
@@ -11,7 +11,7 @@
 #include "Observers/LockChangedObserver.h"
 #include "Observers/MenuObserver.h"
 
-using Settings = QuickLoot::Config::Settings;
+using Settings = QuickLoot::Config::UserSettings;
 
 namespace QuickLoot
 {

--- a/src/MenuVisibilityManager.cpp
+++ b/src/MenuVisibilityManager.cpp
@@ -184,13 +184,13 @@ namespace QuickLoot
 		Observers::MenuObserver::Install();
 	}
 
-	void MenuVisibilityManager::EnableLootMenu(const std::string& modName)
+	void MenuVisibilityManager::DisableLootMenu(const std::string& modName)
 	{
 		_disablingMods.insert(modName);
 		RefreshOpenState();
 	}
 
-	void MenuVisibilityManager::DisableLootMenu(const std::string& modName)
+	void MenuVisibilityManager::EnableLootMenu(const std::string& modName)
 	{
 		_disablingMods.erase(modName);
 		RefreshOpenState();

--- a/src/MenuVisibilityManager.cpp
+++ b/src/MenuVisibilityManager.cpp
@@ -198,21 +198,27 @@ namespace QuickLoot
 
 	void MenuVisibilityManager::OnCameraStateChanged(RE::CameraState state)
 	{
-		logger::trace("OnCameraStateChanged: {}", std::to_underlying(state));
+		if (LOG_EVENTS) {
+			logger::trace("OnCameraStateChanged: {}", std::to_underlying(state));
+		}
 
 		RefreshOpenState();
 	}
 
 	void MenuVisibilityManager::OnCombatStateChanged(RE::ACTOR_COMBAT_STATE state)
 	{
-		logger::trace("OnCombatStateChanged: {}", std::to_underlying(state));
+		if (LOG_EVENTS) {
+			logger::trace("OnCombatStateChanged: {}", std::to_underlying(state));
+		}
 
 		RefreshOpenState();
 	}
 
 	void MenuVisibilityManager::OnContainerChanged(RE::FormID container)
 	{
-		logger::trace("OnContainerChanged: {:08X}", container);
+		if (LOG_EVENTS) {
+			logger::trace("OnContainerChanged: {:08X}", container);
+		}
 
 		if (_currentContainer.get() && container == _currentContainer.get()->GetFormID()) {
 			RefreshInventory();
@@ -221,7 +227,9 @@ namespace QuickLoot
 
 	void MenuVisibilityManager::OnCrosshairRefChanged(const RE::ObjectRefHandle& ref)
 	{
-		logger::trace("OnCrosshairRefChanged: {:08X}", ref.get() ? ref.get()->GetFormID() : 0);
+		if (LOG_EVENTS) {
+			logger::trace("OnCrosshairRefChanged: {:08X}", ref.get() ? ref.get()->GetFormID() : 0);
+		}
 
 		if (ref != _focusedRef) {
 			_focusedRef = ref;
@@ -231,7 +239,9 @@ namespace QuickLoot
 
 	void MenuVisibilityManager::OnLifeStateChanged(RE::Actor& actor)
 	{
-		logger::trace("OnLifeStateChanged: {:08X}", actor.GetFormID());
+		if (LOG_EVENTS) {
+			logger::trace("OnLifeStateChanged: {:08X}", actor.GetFormID());
+		}
 
 		if (actor.GetHandle() == _focusedRef) {
 			RefreshOpenState();
@@ -240,7 +250,9 @@ namespace QuickLoot
 
 	void MenuVisibilityManager::OnLockChanged(RE::TESObjectREFR& container)
 	{
-		logger::trace("OnLockChanged: {:08X}", container.GetFormID());
+		if (LOG_EVENTS) {
+			logger::trace("OnLockChanged: {:08X}", container.GetFormID());
+		}
 
 		if (Settings::ShowWhenUnlocked() && container.GetHandle() == _focusedRef) {
 			RefreshOpenState();
@@ -249,7 +261,9 @@ namespace QuickLoot
 
 	void MenuVisibilityManager::OnMenuOpenClose(bool opening, const RE::BSFixedString& menuName)
 	{
-		logger::trace("OnMenuOpenClose: {} {}", opening ? "Open" : "Close", menuName);
+		if (LOG_EVENTS) {
+			logger::trace("OnMenuOpenClose: {} {}", opening ? "Open" : "Close", menuName);
+		}
 
 		// Always ignore events related to the loot menu to avoid feedback loops
 		if (menuName == LootMenu::MENU_NAME) {

--- a/src/MenuVisibilityManager.h
+++ b/src/MenuVisibilityManager.h
@@ -26,6 +26,8 @@ namespace QuickLoot
 		static void OnMenuOpenClose(bool opening, const RE::BSFixedString& menuName);
 
 	private:
+		static constexpr bool LOG_EVENTS = false;
+
 		static inline RE::ObjectRefHandle _focusedRef{};
 		static inline RE::ObjectRefHandle _currentContainer{};
 		static inline std::set<std::string> _disablingMods{};

--- a/src/MenuVisibilityManager.h
+++ b/src/MenuVisibilityManager.h
@@ -34,7 +34,8 @@ namespace QuickLoot
 
 		static RE::TESObjectREFRPtr GetContainerObject(RE::ObjectRefHandle ref);
 		static bool IsValidCameraState(RE::CameraState state);
-		static bool IsBlockingMenuOpen();
+		static const char* GetMenuNameSafe(const RE::IMenu* menu);
+		static const char* FindBlockingMenu();
 		static bool CanOpen(const RE::TESObjectREFRPtr& container);
 		static void RefreshOpenState();
 		static void RefreshInventory();

--- a/src/MenuVisibilityManager.h
+++ b/src/MenuVisibilityManager.h
@@ -14,8 +14,8 @@ namespace QuickLoot
 
 		static void InstallHooks();
 
-		static void EnableLootMenu(const std::string& modName);
 		static void DisableLootMenu(const std::string& modName);
+		static void EnableLootMenu(const std::string& modName);
 
 		static void OnCameraStateChanged(RE::CameraState state);
 		static void OnCombatStateChanged(RE::ACTOR_COMBAT_STATE state);

--- a/src/MenuVisibilityManager.h
+++ b/src/MenuVisibilityManager.h
@@ -36,6 +36,7 @@ namespace QuickLoot
 		static bool IsValidCameraState(RE::CameraState state);
 		static const char* GetMenuNameSafe(const RE::IMenu* menu);
 		static const char* FindBlockingMenu();
+		static bool IsContainerBlacklisted(const RE::TESObjectREFRPtr& container);
 		static bool CanOpen(const RE::TESObjectREFRPtr& container);
 		static void RefreshOpenState();
 		static void RefreshInventory();

--- a/src/SanityChecks.cpp
+++ b/src/SanityChecks.cpp
@@ -1,6 +1,7 @@
 #include "SanityChecks.h"
 
 #include "LootMenu.h"
+#include "Config/SystemSettings.h"
 #include "Util/FormUtil.h"
 
 void ShowFatalError(const char* message)
@@ -38,7 +39,7 @@ bool QuickLoot::SanityChecks::ValidateSWF()
 {
 	logger::info("Checking SWF files...");
 
-	if (std::filesystem::exists(LEGACY_SWF)) {
+	if (!Config::SystemSettings::SkipOldSwfCheck() && std::filesystem::exists(LEGACY_SWF)) {
 		logger::error("LootMenu.swf present");
 
 		ShowFatalError(
@@ -46,7 +47,8 @@ bool QuickLoot::SanityChecks::ValidateSWF()
 			"This file is no longer used by QuickLoot IE and was "
 			"most likely provided by an incompatible UI patch. "
 			"It will be ignored."
-			"\n\nExit Game now? (Recommend yes)");
+			"\n\nSet skipOldSwfCheck to true in QuickLootIE.json to disable this message."
+			"\n\nExit Game now? (Recommend no)");
 
 		// The presence of LootMenu.swf does not prevent QuickLoot from working,
 		// so it shouldn't fail the sanity check.
@@ -63,6 +65,7 @@ bool QuickLoot::SanityChecks::ValidateSWF()
 				"This file is required by QuickLoot IE. "
 				"Please make sure the mod is installed correctly."
 				"\n\nExit Game now? (Recommend yes)");
+
 			return false;
 		}
 
@@ -81,6 +84,7 @@ bool QuickLoot::SanityChecks::ValidateSWF()
 		ShowFatalError(
 			"The installed version of LootMenuIE.swf is not compatible with QuickLoot IE."
 			"\n\nExit Game now? (Recommend yes)");
+
 		return false;
 
 	default:

--- a/src/SanityChecks.cpp
+++ b/src/SanityChecks.cpp
@@ -34,7 +34,6 @@ bool QuickLoot::SanityChecks::ValidatePlugins()
 	return true;
 }
 
-
 bool QuickLoot::SanityChecks::ValidateSWF()
 {
 	logger::info("Checking SWF files...");
@@ -54,25 +53,26 @@ bool QuickLoot::SanityChecks::ValidateSWF()
 		//return false;
 	}
 
-	if (!std::filesystem::exists(CURRENT_SWF)) {
-		logger::error("LootMenuIE.swf missing");
-
-		ShowFatalError(
-			"LootMenuIE.swf is missing. "
-			"This file is required by QuickLoot IE. "
-			"Please make sure the mod is installed correctly."
-			"\n\nExit Game now? (Recommend yes)");
-		return false;
-	}
-
 	switch (const int version = LootMenu::GetSwfVersion()) {
 	case -2:
+		if (!std::filesystem::exists(CURRENT_SWF)) {
+			logger::error("LootMenuIE.swf missing");
+
+			ShowFatalError(
+				"LootMenuIE.swf is missing. "
+				"This file is required by QuickLoot IE. "
+				"Please make sure the mod is installed correctly."
+				"\n\nExit Game now? (Recommend yes)");
+			return false;
+		}
+
 		logger::error("Failed to load swf");
 
 		ShowFatalError(
 			"LootMenuIE.swf exists but failed to load. "
 			"If you are using a reskin, make sure all of its dependencies are installed."
 			"\n\nExit Game now? (Recommend yes)");
+
 		return false;
 
 	case -1:

--- a/src/Util/FormUtil.cpp
+++ b/src/Util/FormUtil.cpp
@@ -2,17 +2,23 @@
 
 namespace QuickLoot::Util
 {
-	RE::TESForm* FormUtil::GetFormFromIdentifier(const std::string& identifier)
+	RE::FormID FormUtil::ParseFormID(const std::string& identifier)
 	{
 		std::istringstream ss{ identifier };
 		std::string plugin, id;
 
 		std::getline(ss, plugin, '|');
 		std::getline(ss, id);
-		RE::FormID relativeID;
-		std::istringstream{ id } >> std::hex >> relativeID;
-		const auto dataHandler = RE::TESDataHandler::GetSingleton();
-		return dataHandler ? dataHandler->LookupForm(relativeID, plugin) : nullptr;
+
+		RE::FormID localFormID;
+		std::istringstream{ id } >> std::hex >> localFormID;
+
+		return RE::TESDataHandler::GetSingleton()->LookupFormID(localFormID, plugin);
+	}
+
+	RE::TESForm* FormUtil::GetFormFromIdentifier(const std::string& identifier)
+	{
+		return RE::TESForm::LookupByID(ParseFormID(identifier));
 	}
 
 	std::string FormUtil::GetIdentifierFromForm(RE::TESForm* form)

--- a/src/Util/FormUtil.h
+++ b/src/Util/FormUtil.h
@@ -12,6 +12,8 @@ namespace QuickLoot::Util
 		FormUtil& operator=(FormUtil&) = delete;
 		FormUtil& operator=(FormUtil&&) = delete;
 
+		static RE::FormID ParseFormID(const std::string& identifier);
+
 		static RE::TESForm* GetFormFromIdentifier(const std::string& identifier);
 
 		static std::string GetIdentifierFromForm(RE::TESForm* form);

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -13,6 +13,7 @@
 #include "LootMenu.h"
 #include "MenuVisibilityManager.h"
 #include "SanityChecks.h"
+#include "Config/SystemSettings.h"
 
 void OnSKSEMessage(SKSE::MessagingInterface::Message* msg)
 {
@@ -22,6 +23,8 @@ void OnSKSEMessage(SKSE::MessagingInterface::Message* msg)
 		break;
 
 	case SKSE::MessagingInterface::kDataLoaded:
+		QuickLoot::Config::SystemSettings::Update();
+
 		if (!QuickLoot::SanityChecks::PerformChecks()) {
 			logger::error("Sanity checks failed. Disabling QuickLootIE.");
 			return;
@@ -29,7 +32,6 @@ void OnSKSEMessage(SKSE::MessagingInterface::Message* msg)
 
 		QuickLoot::Config::Papyrus::Init();
 
-		// Do this after settings are loaded
 		QuickLoot::Input::InputManager::Install();
 
 		QuickLoot::LootMenu::Register();
@@ -83,7 +85,7 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Query(const SKSE::QueryInterface*, 
 
 extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* skse)
 {
-	InitializeLog(spdlog::level::trace);
+	InitializeLog();
 
 	logger::info("Loaded plugin {} {}", Plugin::NAME, Plugin::VERSION.string("."));
 


### PR DESCRIPTION
Implements the infrastructure to load settings that don't belong in the MCM from a JSON file.

The following settings are currently supported:
- `logLevel`/`logFlush`: Determines the logging verbosity
- `skipOldSwfCheck`: Disables the warning with `LootMenu.swf` is present
- `menuWhitelist`: Allows whitelisting menus that don't have `kAlwaysOpen` set
- `containerBlacklist`: Allows blacklisting containers (Closes #60)

Also fixes #73.